### PR TITLE
Fixing Issue #34 removed base64 encoding from SUK response.

### DIFF
--- a/SqrlForNet/SqrlCommandWorker.cs
+++ b/SqrlForNet/SqrlCommandWorker.cs
@@ -793,7 +793,8 @@ namespace SqrlForNet
             {
                 var idk = GetClientParams()["idk"];
                 var suk = Options.GetUserSukInternal(idk, Request.HttpContext);
-                responseMessageBuilder.AppendLine("suk=" + Base64UrlTextEncoder.Encode(Encoding.ASCII.GetBytes(suk)), true);
+                //Removed Base64 Encoding for SUK which was causing a validation error on VUK / URS
+                responseMessageBuilder.AppendLine($"suk={suk}", true);
             }
 
             if (!(tifValue.HasFlag(Tif.TransientError) || tifValue.HasFlag(Tif.BadId) ||


### PR DESCRIPTION
This PR Should Fix issue 34, removes the Base64 Encoding from the SUK reponse which was causing a validation issue to the USR/VUK